### PR TITLE
Road to V2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,8 @@
 name: test
 
 on:
-  push:
-    branches: [ dev ]
   pull_request:
-    branches: [ dev ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,46 @@
 version = 3
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -16,17 +52,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
- "libc",
- "num-integer",
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
- "time",
- "winapi",
+ "wasm-bindgen",
+ "windows-targets",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "getrandom"
@@ -40,10 +83,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+
+[[package]]
+name = "js-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -52,14 +127,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
+name = "log"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "num-traits"
@@ -71,19 +142,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.39"
+name = "once_cell"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -96,15 +173,18 @@ checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -113,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -124,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -135,24 +215,14 @@ dependencies = [
 
 [[package]]
 name = "terror"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
+ "anyhow",
  "chrono",
  "serde",
  "serde_derive",
  "serde_json",
  "uuid",
-]
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi",
- "winapi",
 ]
 
 [[package]]
@@ -163,9 +233,9 @@ checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "uuid"
-version = "1.0.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
  "serde",
@@ -178,23 +248,121 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "wasm-bindgen"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "cfg-if",
+ "wasm-bindgen-macro",
 ]
 
 [[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
+name = "wasm-bindgen-backend"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "wasm-bindgen-macro"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "terror"
 description = "Uniform REST error response body, tailored for JSON"
 version = "0.1.3"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.70.0"
 license = "MIT"
 keywords = ["rest", "error", "json"]
 readme = "README.md"
@@ -13,13 +13,18 @@ exclude = ["/ci", ".github"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[dependencies]
+chrono = { version = "0.4.31", optional = true, features = ["serde"] }
+uuid = { version = "1.6.1", features = ["v4", "serde"], optional = true }
+serde = "1.0.193"
+serde_json = "1.0.108"
+serde_derive = "1.0.193"
+
+[dev-dependencies]
+anyhow = "1.0.75"
+
+
 [features]
 time = ["dep:chrono"]
 err_id = ["dep:uuid"]
-
-[dependencies]
-chrono = { version = "0.4.19", optional = true, features = ["serde"] }
-uuid = { version = "1.0.0", features = ["v4", "serde"], optional = true }
-serde = "1.0.137"
-serde_json = "1.0.80"
-serde_derive = "1.0.137"
+mdn = []

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Overview
 
-**TError** (as in Typical Error) is a small library that exposes
-    a configurable and uniform response body representation for
-    typical REST services. It covers most basic aspects such as
-    returned status code, messages, detailed error data and so on.
+**TError** (as in Typical Error) is a small library that exposes a configurable and uniform response body representation for typical REST services. It covers most basic aspects such as returned status code, messages, detailed error data and so on.
 
 ## Getting started
 
@@ -16,31 +13,35 @@ terror = "0.1.3"
 And then start hacking in the code:
 
 ```rust
-let error = Terror::new(500, String::format("generic server error"))
-    .build();
+fn main() {
+    let error = Terror::new(500, String::format("generic server error"))
+        .build();
+}
 ```
 
 You can also add some flavour to it, for example, an error code:
 ```rust
-let error = Terror::new(500, String::format("generic server error"))
-    .error_code(String::from("error.internal"))
-    .build();
+fn main() {
+    let error = Terror::new(500, String::format("generic server error"))
+        .error_code("error.internal")
+        .build();
+}
 ```
 
 ## Architecture
 
 `terror` is built with Rust 1.60.
 
-It's a general intention of `terror` to be serialized into JSON. Therefore,
-    it's designed to be compatible with `serde`. As for the rest, `terror`
-    tries to enforce as little dependencies as possible.
+It's a general intention of `terror` to be serialized into JSON. Therefore, it's designed to be compatible with 
+`serde`. As for the rest, `terror` tries to enforce as little dependencies as possible.
 
 ### Features
 
-It's sometimes convenient to add some extra metadata to your error responses;
-    `terror` offers 2 such things out-of-the-box:
+It's sometimes convenient to add some extra metadata to your error responses; `terror` offers 3 such things 
+out-of-the-box:
 
-* adding a UUID to your error - basically a V4 UUID; handled by crate `uuid`,
-  enabled by feature flag `err_id`
-* including error timestamp - ISO-8601 timestamp, taken at UTC; handled by
-  crate `chrono`, enabled by feature flag `time`.
+| feature  | notion                                    | backend  |
+|:--------:|:------------------------------------------|:--------:|
+| `err_id` | V4 UUID error ID                          |  `uuid`  |
+|  `time`  | ISO-8601 error timestamp at UTC           | `chrono` |
+|  `mdn`   | a link to MDN reference about status code |   n/a    |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
-use std::fmt::Formatter;
+use std::fmt::{Debug, Formatter};
 use serde_derive::{Serialize, Deserialize};
 
 #[cfg(feature = "time")]
 use chrono::{DateTime, Utc};
+use serde::Serialize;
 use serde_json::{Number, Value};
 #[cfg(feature = "err_id")]
 use uuid::Uuid;
@@ -44,18 +45,34 @@ use uuid::Uuid;
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct Terror {
 
+    /// HTTP status code
     pub status: u16,
+
+    /// Full error message
     pub message: String,
+
+    /// Shortened error message; nullable
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub short_message: Option<String>,
+
+    /// Error code; nullable
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
 
+    /// Arbitrary error details
     #[serde(default = "Terror::default_empty_map")]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub details: HashMap<String, Value>,
-    pub reference: Option<String>,
 
+    /// A reference to the MDN about the status code
+    #[cfg(feature = "mdn")]
+    pub reference: String,
+
+    /// Error timestamp as captured by server
     #[cfg(feature = "time")]
     pub timestamp: DateTime<Utc>,
 
+    /// Error ID
     #[cfg(feature = "err_id")]
     pub id: Uuid
 
@@ -82,14 +99,33 @@ impl Terror {
 
     /// Constructs a new builder with the
     /// minimal data provided explicitly.
-    pub fn new(status: u16, msg: String) -> Builder {
+    ///
+    /// ### Examples
+    ///
+    /// For instance,
+    /// ```rust
+    /// use terror::{Terror, Builder};
+    /// let built = Terror::new(429, String::from("some error"))
+    ///     .build();
+    /// ```
+    ///
+    /// Thanks to generic text parameter, the following also works:
+    /// ```rust
+    /// use terror::{Terror, Builder};
+    /// let built = Terror::new(429, "some error")
+    ///     .build();
+    /// ```
+    pub fn new<K: Into<String>>(status: u16, msg: K) -> Builder {
+        let into: String = msg.into();
         Builder {
             status,
-            message: msg,
+            message: into,
             short_message: None,
             error_code: None,
             details: HashMap::new(),
-            reference: None,
+
+            #[cfg(feature = "mdn")]
+            reference: format!("{}/{}", MDN_STATUS_REF, status),
 
             #[cfg(feature = "time")]
             timestamp: Utc::now(),
@@ -97,12 +133,6 @@ impl Terror {
             #[cfg(feature = "err_id")]
             id: Uuid::new_v4(),
         }
-    }
-
-    /// Constructs a new builder with the
-    /// minimal data provided explicitly.
-    pub fn new_str(status: u16, msg: &str) -> Builder {
-        Terror::new(status, String::from(msg))
     }
 
     /// Constructs a new builder from any
@@ -119,8 +149,14 @@ impl Terror {
 
 }
 
+impl Default for Terror {
+    fn default() -> Self {
+        Terror::new(500, "generic error").build()
+    }
+}
+
 /// A builder for [Terror]. Intended
-/// for one-time used, consumed after
+/// for one-time use, consumed after
 /// calling [Builder::build].
 pub struct Builder {
 
@@ -129,7 +165,9 @@ pub struct Builder {
     short_message: Option<String>,
     error_code: Option<String>,
     details: HashMap<String, Value>,
-    reference: Option<String>,
+
+    #[cfg(feature = "mdn")]
+    reference: String,
 
     #[cfg(feature = "time")]
     timestamp: DateTime<Utc>,
@@ -142,227 +180,85 @@ pub struct Builder {
 impl Builder {
     
     /// Adds a short error message.
-    pub fn short_message(mut self, msg: String) -> Builder {
-        self.short_message = Some(msg);
-        self
-    }
-
-    /// Adds a short error message.
-    pub fn short_message_str(mut self, msg: &str) -> Builder {
-        self.short_message = Some(String::from(msg));
+    pub fn shorthand<K: Into<String>>(mut self, msg: K) -> Builder {
+        let into: String = msg.into();
+        self.short_message = Some(into);
         self
     }
 
     /// Adds an error code.
-    pub fn error_code(mut self, code: String) -> Builder {
-        self.error_code = Some(code);
-        self
-    }
-
-    /// Adds an error code.
-    pub fn error_code_str(mut self, code: &str) -> Builder {
-        self.error_code = Some(String::from(code));
+    pub fn error_code<K: Into<String>>(mut self, code: K) -> Builder {
+        let into: String = code.into();
+        self.error_code = Some(into);
         self
     }
 
     /// Adds a text detail.
-    ///
-    /// ### Examples
-    ///
-    /// For instance,
-    /// ```rust
-    /// use terror::{Builder, Terror};
-    /// let built = Terror::new(500, String::from("generic error"))
-    ///     .add_text_detail(String::from("object_name"), String::from("server"))
-    ///     .build();
-    /// ```
-    ///
-    /// ... may be rendered into a JSON like below:
-    ///
-    /// ```json
-    /// {
-    ///     "status" : 500,
-    ///     "message" : "generic error",
-    ///     "details" : {
-    ///         "object_name" : "server"
-    ///     }
-    /// }
-    /// ```
-    pub fn add_text_detail(mut self,
-                           name: String,
-                           value: String) -> Builder {
-        self.details.insert(
-            name,
-            Value::String(value)
-        );
-        self
-    }
-
-    /// A shorthand for [Builder::add_text_detail],
-    /// which allows to pass the key name as `&str`.
-    pub fn add_text_detail_str_key(mut self,
-                                   name: &str,
-                                   value: String) -> Builder {
-        self.details.insert(
-            String::from(name),
-            Value::String(value)
-        );
+    pub fn add_text_detail<K, V>(mut self,
+                                 name: K,
+                                 value: V) -> Builder
+        where K: Into<String>,
+              V: Into<String>
+    {
+        let name: String = name.into();
+        let value: String = value.into();
+        self.details.insert(name, Value::String(value));
         self
     }
 
     /// Adds a numeric detail.
-    ///
-    /// ### Examples
-    ///
-    /// For instance,
-    /// ```rust
-    /// use terror::{Builder, Terror};
-    /// let built = Terror::new(500, String::from("generic error"))
-    ///     .add_int_detail(String::from("object_id"), 922i64)
-    ///     .build();
-    /// ```
-    ///
-    /// ... may be rendered into a JSON like below:
-    ///
-    /// ```json
-    /// {
-    ///     "status" : 500,
-    ///     "message" : "generic error",
-    ///     "details" : {
-    ///         "object_id" : 922
-    ///     }
-    /// }
-    /// ```
-    pub fn add_int_detail(mut self,
-                          name: String,
-                          value: i64) -> Builder {
-        self.details.insert(
-            name,
-            Value::Number(Number::from(value))
-        );
-        self
-    }
-
-    /// A shorthand for [Builder::add_int_detail],
-    /// which allows to pass the key name as `&str`.
-    pub fn add_int_detail_str_key(mut self,
-                                  name: &str,
-                                  value: i64) -> Builder {
-        self.details.insert(
-            String::from(name),
-            Value::Number(Number::from(value))
-        );
+    pub fn add_int_detail<K: Into<String>>(mut self,
+                                           name: K,
+                                           value: i64) -> Builder {
+        let into: String = name.into();
+        self.details.insert(into, Value::Number(Number::from(value)));
         self
     }
 
     /// Adds a boolean detail.
-    ///
-    /// ### Examples
-    ///
-    /// For instance,
-    /// ```rust
-    /// use terror::{Builder, Terror};
-    /// let built = Terror::new(500, String::from("generic error"))
-    ///     .add_bool_detail(String::from("object_up"), false)
-    ///     .build();
-    /// ```
-    ///
-    /// ... may be rendered into a JSON like below:
-    ///
-    /// ```json
-    /// {
-    ///     "status" : 500,
-    ///     "message" : "generic error",
-    ///     "details" : {
-    ///         "object_up" : false
-    ///     }
-    /// }
-    /// ```
-    pub fn add_bool_detail(mut self,
-                           name: String,
-                           value: bool) -> Builder {
-        self.details.insert(
-            name,
-            Value::Bool(value)
-        );
+    pub fn add_bool_detail<K: Into<String>>(mut self,
+                                            name: K,
+                                            value: bool) -> Builder {
+        let into: String = name.into();
+        self.details.insert(into, Value::Bool(value));
         self
     }
 
-    /// A shorthand for [Builder::add_bool_detail],
-    /// which allows to pass the key name as `&str`.
-    pub fn add_bool_detail_str_key(mut self,
-                                  name: &str,
-                                  value: bool) -> Builder {
-        self.details.insert(
-            String::from(name),
-            Value::Bool(value)
-        );
+    /// Adds an [Value] object as detail.
+    pub fn add_value_detail<K: Into<String>>(mut self,
+                                             name: K,
+                                             value: Value) -> Builder {
+        let into: String = name.into();
+        self.details.insert(into, value);
         self
     }
 
-    /// Adds an arbitrary object as detail. Requires
-    /// to be passed as a pointer.
-    ///
-    /// ### Examples
-    ///
-    /// For instance,
-    /// ```rust
-    /// use terror::{Builder, Terror};
-    /// use serde_json::{json, Value};
-    ///
-    /// let built = Terror::new(500, String::from("generic error"))
-    ///     .add_value_detail(
-    ///         String::from("object"),
-    ///         Value::from(json!({
-    ///             "id" : 94i32,
-    ///             "name" : "server"
-    ///         }))
-    ///     )
-    ///     .build();
-    /// ```
-    ///
-    /// ... may be rendered into a JSON like below:
-    ///
-    /// ```json
-    /// {
-    ///     "status" : 500,
-    ///     "message" : "generic error",
-    ///     "details" : {
-    ///         "object" : {
-    ///             "id" : 94,
-    ///             "name" : "server"
-    ///         }
-    ///     }
-    /// }
-    /// ```
-    pub fn add_value_detail(mut self,
-                            name: String,
-                            value: Value) -> Builder {
-        self.details.insert(
-            name,
-            value
-        );
+    /// Adds a `null` object as detail.
+    pub fn add_null_detail<K: Into<String>>(mut self, name: K) -> Builder {
+        let into: String = name.into();
+        self.details.insert(into, Value::Null);
         self
     }
 
-    /// A shorthand for [Builder::add_value_detail],
-    /// which allows to pass the key name as `&str`.
-    pub fn add_value_detail_str_key(mut self,
-                                    name: &str,
-                                    value: Value) -> Builder {
-        self.details.insert(
-            String::from(name),
-            value
-        );
-        self
-    }
-
-    /// Instructs the builder to attach
-    /// a reference to MDN page explaining
-    /// the HTTP status code.
-    pub fn reference(mut self) -> Builder {
-        let url = format!("{}/{}", MDN_STATUS_REF, self.status);
-        self.reference = Some(url);
+    /// Adds a serialised struct detail from a
+    /// provided [Serialize]-annotated object.
+    ///
+    /// ### Panics
+    ///
+    /// This method expects that `obj` parameter
+    /// can be correctly serialised into JSON
+    /// and panics if [serde_json::to_value]
+    /// fails.
+    pub fn add_struct_detail<K, S>(mut self,
+                                   name: K,
+                                   obj: S) -> Builder
+        where K: Into<String>,
+              S: Serialize + Debug
+    {
+        let into: String = name.into();
+        let value = serde_json::to_value(&obj)
+            .expect(format!("failed to serialise: {:?}", &obj).as_str());
+        self.details.insert(into, value);
         self
     }
 
@@ -376,7 +272,9 @@ impl Builder {
             message: self.message.clone(),
             short_message: self.short_message.clone(),
             error_code: self.error_code.clone(),
-            details:self.details,
+            details: self.details,
+
+            #[cfg(feature = "mdn")]
             reference: self.reference.clone(),
 
             #[cfg(feature = "time")]
@@ -389,6 +287,7 @@ impl Builder {
 
 }
 
+#[cfg(feature = "mdn")]
 const MDN_STATUS_REF: &str = "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status";
 
 #[cfg(test)]
@@ -397,282 +296,168 @@ mod no_feature_test {
     use std::fmt;
     use std::fmt::Formatter;
     use serde_json::{json, Value};
-    use crate::{MDN_STATUS_REF, Terror};
+    use crate::{Builder, Terror};
+
+    type R = anyhow::Result<()>;
 
     #[test]
-    fn build_with_explicit_status() {
-        let msg = "generic error";
-        let built = Terror::new(
-            404,
-            String::from(msg)
-        )
-            .build();
+    fn build_with_explicit_status() -> R {
+        let built = builder().build();
 
-        assert_eq!(404, built.status);
-        assert_eq!(
-            String::from(msg),
-            built.message
-        );
+        let expected = json!({
+            "status": 404,
+            "message": "generic error"
+        });
+        let actual = serde_json::to_value(built)?;
+        compare(expected, actual)
     }
 
     #[test]
-    fn build_from_error() {
+    fn build_from_error() -> R {
         let error = TestError;
         let built = Terror::from_error(error)
             .build();
 
-        assert_eq!(500, built.status);
-        assert_eq!(
-            String::from("generic error"),
-            built.message
-        )
+        let expected = json!({
+            "status": 500,
+            "message": "generic error"
+        });
+        let actual = serde_json::to_value(built)?;
+        compare(expected, actual)
     }
 
     #[test]
-    fn build_no_short_message_set() {
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
+    fn build_w_shorthand() -> R {
+        let built = builder()
+            .shorthand("generic")
             .build();
 
-        assert!(built.short_message.is_none())
+        let expected = json!({
+            "status": 404,
+            "message": "generic error",
+            "short_message": "generic"
+        });
+        let actual = serde_json::to_value(built)?;
+        compare(expected, actual)
     }
 
     #[test]
-    fn build_short_message_set() {
-        let short_message = "generic";
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
-            .short_message(String::from(short_message))
+    fn build_w_error_code() -> R {
+        let built = builder()
+            .error_code("generic.failure")
             .build();
 
-        assert!(built.short_message.is_some());
-        assert_eq!(
-            String::from(short_message),
-            built.short_message.unwrap()
-        );
+        let expected = json!({
+            "status": 404,
+            "message": "generic error",
+            "error_code": "generic.failure"
+        });
+        let actual = serde_json::to_value(built)?;
+        compare(expected, actual)
     }
 
     #[test]
-    fn build_short_message_shorthand_set() {
-        let short_message = "generic";
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
-            .short_message_str(short_message)
+    fn build_w_string_detail() -> R {
+        let built = builder()
+            .add_text_detail("key", "val")
             .build();
 
-        assert!(built.short_message.is_some());
-        assert_eq!(
-            String::from(short_message),
-            built.short_message.unwrap()
-        );
+        let expected = json!({
+            "status": 404,
+            "message": "generic error",
+            "details": {
+                "key": "val"
+            }
+        });
+        let actual = serde_json::to_value(built)?;
+        compare(expected, actual)
     }
 
     #[test]
-    fn build_no_error_code_set() {
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
+    fn build_w_number_detail() -> R {
+        let built = builder()
+            .add_int_detail("key", 53i64)
             .build();
 
-        assert!(built.error_code.is_none())
+        let expected = json!({
+            "status": 404,
+            "message": "generic error",
+            "details": {
+                "key": 53
+            }
+        });
+        let actual = serde_json::to_value(built)?;
+        compare(expected, actual)
     }
 
     #[test]
-    fn build_error_code_set() {
-        let error_code = "generic.failure";
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
-            .error_code(String::from(error_code))
+    fn build_w_bool_detail() -> R {
+        let built = builder()
+            .add_bool_detail("key", true)
             .build();
 
-        assert!(built.error_code.is_some());
-        assert_eq!(
-            String::from(error_code),
-            built.error_code.unwrap()
-        );
+        let expected = json!({
+            "status": 404,
+            "message": "generic error",
+            "details": {
+                "key": true
+            }
+        });
+        let actual = serde_json::to_value(built)?;
+        compare(expected, actual)
     }
 
     #[test]
-    fn build_error_code_shorthand_set() {
-        let error_code = "generic.failure";
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
-            .error_code_str(error_code)
+    fn build_w_value_detail() -> R {
+        let detail = json!({
+            "id" : 25,
+            "name" : "server"
+        });
+
+        let built = builder()
+            .add_value_detail("key", detail)
             .build();
 
-        assert!(built.error_code.is_some());
-        assert_eq!(
-            String::from(error_code),
-            built.error_code.unwrap()
-        );
+        let expected = json!({
+            "status": 404,
+            "message": "generic error",
+            "details": {
+                "key": {
+                    "id": 25,
+                    "name": "server"
+                }
+            }
+        });
+        let actual = serde_json::to_value(built)?;
+        compare(expected, actual)
     }
 
     #[test]
-    fn build_no_reference_set() {
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
+    fn build_with_several_details() -> R {
+        let built = builder()
+            .add_text_detail("str", "val")
+            .add_int_detail("num", 53i64)
+            .add_bool_detail("flg", true)
             .build();
 
-        assert!(built.reference.is_none())
-    }
+        let expected = json!({
+            "status": 404,
+            "message": "generic error",
+            "details": {
+                "str": "val",
+                "num": 53,
+                "flg": true
+            }
+        });
 
-    #[test]
-    fn build_reference_set() {
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
-            .reference()
-            .build();
-
-        assert!(built.reference.is_some());
-        assert_eq!(
-            format!("{}/{}", MDN_STATUS_REF, 404),
-            built.reference.unwrap()
-        );
-    }
-
-    #[test]
-    fn build_no_details() {
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
-            .build();
-
-        assert!(built.details.is_empty());
-    }
-
-    #[test]
-    fn build_with_string_detail() {
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
-            .add_text_detail(
-                String::from("key"),
-                String::from("val")
-            )
-            .build();
-
-        assert!(!built.details.is_empty());
-        assert_eq!(1, built.details.len());
-        assert!(built.details.get("key").is_some());
-        assert_eq!(
-            Value::String(String::from("val")),
-            *built.details.get("key")
-                .unwrap()
-        );
-    }
-
-    #[test]
-    fn build_with_number_detail() {
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
-            .add_int_detail(
-                String::from("key"),
-                53i64
-            )
-            .build();
-
-        assert!(!built.details.is_empty());
-        assert_eq!(1, built.details.len());
-        assert!(built.details.get("key").is_some());
-        assert_eq!(
-            Value::from(53i64),
-            *built.details.get("key")
-                .unwrap()
-        );
-    }
-
-    #[test]
-    fn build_with_bool_detail() {
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
-            .add_bool_detail(
-                String::from("key"),
-                true
-            )
-            .build();
-
-        assert!(!built.details.is_empty());
-        assert_eq!(1, built.details.len());
-        assert!(built.details.get("key").is_some());
-        assert_eq!(
-            Value::Bool(true),
-            *built.details.get("key")
-                .unwrap()
-        );
-    }
-
-    #[test]
-    fn build_with_struct_detail() {
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
-            .add_value_detail(
-                String::from("key"),
-                Value::from(json!({
-                    "id" : 25,
-                    "name" : "server"
-                }))
-            )
-            .build();
-
-        assert!(!built.details.is_empty());
-        assert_eq!(1, built.details.len());
-        assert!(built.details.get("key").is_some());
-    }
-
-    #[test]
-    fn build_with_several_details() {
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        )
-            .add_text_detail(
-                String::from("str"),
-                String::from("val")
-            )
-            .add_int_detail(
-                String::from("num"),
-                53i64
-            )
-            .add_bool_detail(
-                String::from("flg"),
-                true
-            )
-            .build();
-
-
-        assert!(!built.details.is_empty());
-        assert_eq!(3, built.details.len());
-        assert!(built.details.contains_key("str"));
-        assert!(built.details.contains_key("num"));
-        assert!(built.details.contains_key("flg"));
+        let actual = serde_json::to_value(built)?;
+        compare(expected, actual)
     }
 
     #[test]
     #[cfg(not(feature = "err_id"))]
     #[cfg(not(feature = "time"))]
+    #[cfg(not(feature = "mdn"))]
     fn deserialize_all_fields() {
         let inbound = json!({
             "status" : 405u16,
@@ -683,7 +468,6 @@ mod no_feature_test {
                 "allowed" : [ "GET" ],
                 "got" : "OPTIONS"
             },
-            "reference" : format!("{}/{}", MDN_STATUS_REF, 405)
         });
 
         let as_struct = serde_json::from_value(inbound);
@@ -693,7 +477,7 @@ mod no_feature_test {
             405,
             String::from("Method not allowed; use GET")
         )
-            .short_message(String::from("Not allowed"))
+            .shorthand(String::from("Not allowed"))
             .error_code(String::from("web.generic"))
             .add_text_detail(
                 String::from("got"),
@@ -705,7 +489,6 @@ mod no_feature_test {
                     Value::String(String::from("GET"))
                 ])
             )
-            .reference()
             .build();
 
         assert_eq!(expected, as_struct.unwrap());
@@ -714,6 +497,7 @@ mod no_feature_test {
     #[test]
     #[cfg(not(feature = "err_id"))]
     #[cfg(not(feature = "time"))]
+    #[cfg(not(feature = "mdn"))]
     fn deserialize_some_fields() {
         let inbound = json!({
             "status" : 405u16,
@@ -745,44 +529,117 @@ mod no_feature_test {
 
     impl Error for TestError {}
 
+    fn compare(expected: Value, mut actual: Value) -> R {
+
+        #[cfg(feature = "time")]
+        actual.as_object_mut().unwrap().remove("timestamp");
+
+        #[cfg(feature = "err_id")]
+        actual.as_object_mut().unwrap().remove("id");
+
+        #[cfg(feature = "mdn")]
+        actual.as_object_mut().unwrap().remove("reference");
+
+        assert_eq!(expected, actual);
+        Ok(())
+    }
+
+    fn builder() -> Builder {
+        Terror::new(404, "generic error")
+    }
+
 }
 
-#[cfg(all(test, feature = "err_id", feature = "time"))]
+#[cfg(all(test, feature = "err_id", feature = "time", feature = "mdn"))]
 mod with_features_test {
     use std::error::Error;
     use std::fmt;
     use std::fmt::Formatter;
     use std::str::FromStr;
     use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
-    use serde_json::json;
+    use serde_json::{json, Value};
     use uuid::Uuid;
-    use crate::{Terror};
+    use crate::{Builder, Terror};
+
+    type R = anyhow::Result<()>;
 
     #[test]
-    fn build_with_explicit_status() {
-        let built = Terror::new(
-            404,
-            String::from("generic error")
-        );
+    fn build_w_explicit_status() -> R {
+        let mut built = builder().build();
+
+        let now = Utc::now();
 
         assert_eq!(4, built.id.get_version_num());
         assert_eq!(
-            Utc::now().date(),
-            built.timestamp.date()
-        )
+            now.date_naive(),
+            built.timestamp.date_naive()
+        );
+
+        // overwrite to check json values
+        let uuid = Uuid::new_v4();
+        built.id = uuid;
+        built.timestamp = now;
+
+        let expected = json!({
+            "status": 404,
+            "message": "generic error",
+            "id": uuid,
+            "timestamp": now,
+            "reference": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404"
+        });
+        let actual = serde_json::to_value(built)?;
+        compare(expected, actual)
     }
 
     #[test]
-    fn build_from_error() {
+    fn build_from_error() -> R {
         let error = TestError;
-        let built = Terror::from_error(error)
+        let mut built = Terror::from_error(error)
             .build();
+
+        let now = Utc::now();
 
         assert_eq!(4, built.id.get_version_num());
         assert_eq!(
-            Utc::now().date(),
-            built.timestamp.date()
-        )
+            now.date_naive(),
+            built.timestamp.date_naive()
+        );
+
+        // overwrite to check json values
+        let uuid = Uuid::new_v4();
+        built.id = uuid;
+        built.timestamp = now;
+
+        let expected = json!({
+            "status": 500,
+            "message": "generic error",
+            "id": uuid,
+            "timestamp": now,
+            "reference": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500"
+        });
+        let actual = serde_json::to_value(built)?;
+        compare(expected, actual)
+    }
+
+    #[test]
+    fn build_w_reference() -> R {
+        let mut built = builder().build();
+
+        // overwrite to check json values
+        let now = Utc::now();
+        let uuid = Uuid::new_v4();
+        built.id = uuid;
+        built.timestamp = now;
+
+        let expected = json!({
+            "status": 404,
+            "message": "generic error",
+            "id": uuid,
+            "timestamp": now,
+            "reference": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404"
+        });
+        let actual = serde_json::to_value(built)?;
+        compare(expected, actual)
     }
 
     #[test]
@@ -791,24 +648,22 @@ mod with_features_test {
             "status" : 405u16,
             "message" : "Method not allowed; use GET",
             "id" : "2d10a950-d6f4-11ec-ab97-00155d887325",
-            "timestamp" : "2022-01-01T21:00:00Z"
+            "timestamp" : "2022-01-01T21:00:00Z",
+            "reference": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405"
         });
 
         let as_struct = serde_json::from_value(inbound);
         assert!(as_struct.is_ok());
 
-        let mut expected = Terror::new(
-            405,
-            String::from("Method not allowed; use GET")
-        )
+        let mut expected = Terror::new(405,"Method not allowed; use GET")
             .build();
 
         expected.id = Uuid::from_str("2d10a950-d6f4-11ec-ab97-00155d887325")
             .unwrap();
-        expected.timestamp = DateTime::from_utc(
+        expected.timestamp = DateTime::from_naive_utc_and_offset(
             NaiveDateTime::new(
-                NaiveDate::from_ymd(2022, 1, 1),
-                NaiveTime::from_hms(21, 0, 0)
+                NaiveDate::from_ymd_opt(2022, 1, 1).unwrap(),
+                NaiveTime::from_hms_opt(21, 0, 0).unwrap()
             ),
             Utc
         );
@@ -826,5 +681,14 @@ mod with_features_test {
     }
 
     impl Error for TestError {}
+
+    fn compare(expected: Value, actual: Value) -> R {
+        assert_eq!(expected, actual);
+        Ok(())
+    }
+
+    fn builder() -> Builder {
+        Terror::new(404, "generic error")
+    }
 
 }


### PR DESCRIPTION
## API changes

### Breaking changes
This change set bears breaking API changes:

- `Builder::short_message` renamed into `shorthand`;
- `Builder::reference` is deprecated in favour of crate-wide `mdn` feature-flag;
- all `str` methods are deprecated, `String` methods also have a different contract to enable a more concise API:

```rust
pub fn func<K: Into<String>>(status: u16, msg: K);
```

### Minor changes

- `Builder::add_null_detail` -- allows adding `null` JSON values;
- `Builder::add_struct_detail` -- converts a `Serialize` struct into a `serde_json::Value`.
- an implementation of `Default` for `Terror`.

## Maintenance

- MSRV: 1.64.0 => 1.70.0
- packages upgraded to their latest versions