### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.70.0"
 license = "MIT"
 keywords = ["rest", "error", "json"]
 readme = "README.md"
-homepage = "https://github.com/artkonr/terror"
+repository = "https://github.com/artkonr/terror"
 
 exclude = ["/ci", ".github"]
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.